### PR TITLE
removing border className from toggle group on two-toggle buttons bec…

### DIFF
--- a/src/components/font-size-toggle.tsx
+++ b/src/components/font-size-toggle.tsx
@@ -15,7 +15,6 @@ export function FontSizeToggle() {
         if (value && currentfontSize !== value) toggleFontSize();
       }}
       variant="outline"
-      className="border border-input"
     >
       <ToggleGroupItem
         value="small"

--- a/src/components/har/toolbar.tsx
+++ b/src/components/har/toolbar.tsx
@@ -49,7 +49,6 @@ export function Toolbar({ onViewChange }: ToolbarProps) {
             if (value) setView(value);
           }}
           variant="outline"
-          className="border border-input"
         >
           <ToggleGroupItem
             value="all"


### PR DESCRIPTION
…ause it added an unnecessary border